### PR TITLE
Add option to format the search results in `/etc/hosts` format

### DIFF
--- a/actions/search_instances.go
+++ b/actions/search_instances.go
@@ -27,9 +27,7 @@ func (s searcher) SearchInstancesPrefix(c gcloud.Client, args config.Args) error
 		return fmt.Errorf("[SearchPrefix] couldn't search instances with prefix %s err: %v", pattern, err)
 	}
 	logger.Infof("Search By Prefix Result: ")
-	for _, ins := range insts {
-		logger.Infof("%s", ins)
-	}
+	s.formatInstances(insts, args)
 	return nil
 }
 
@@ -44,9 +42,7 @@ func (s searcher) SearchInstancesRegex(c gcloud.Client, args config.Args) error 
 		return fmt.Errorf("[SearchRegex] couldn't search instances with regex %s err: %v", regex, err)
 	}
 	logger.Infof("Search By Regex Result: ")
-	for _, ins := range insts {
-		logger.Infof("%s", ins)
-	}
+	s.formatInstances(insts, args)
 	return nil
 }
 
@@ -56,4 +52,18 @@ func (s searcher) searchInstances(c gcloud.Client, args config.Args, matcher sto
 		return nil, err
 	}
 	return s.finder.Search(s.ctx, projs.Names(), matcher)
+}
+
+func (s searcher) formatInstances(insts []gcloud.Instance, args config.Args) error {
+	hostMapping := args.InstanceCmdArgs.HostMapping
+	if hostMapping {
+		for _, ins := range insts {
+			fmt.Printf("%-16s  %s\n", ins.IP(), ins.Name)
+		}
+		return nil
+	}
+	for _, ins := range insts {
+		fmt.Printf("%s\n", ins)
+	}
+	return nil
 }

--- a/config/loader.go
+++ b/config/loader.go
@@ -9,9 +9,10 @@ import (
 )
 
 type InstanceCmdArgs struct {
-	Prefix  string
-	Regex   string
-	Refresh bool
+	Prefix      string
+	Regex       string
+	Refresh     bool
+	HostMapping bool
 }
 
 type Login struct {
@@ -69,6 +70,7 @@ func MustLoad() {
 	instanceCommand.BoolVar(&instanceArgs.Refresh, "refresh", true, "refresh instances list in store")
 	instanceCommand.StringVar(&instanceArgs.Prefix, "prefix", "", "search instances by common prefix")
 	instanceCommand.StringVar(&instanceArgs.Regex, "regex", "", "search instances by regex")
+	instanceCommand.BoolVar(&instanceArgs.HostMapping, "host_mapping", false, "return the search results in `/etc/hosts` file format")
 	instanceCommand.StringVar(&args.Login.Session, "session", "login-session", "login sesssion name")
 	instanceCommand.StringVar(&args.Login.TemplatesDir, "templates", defaultCfg.TemplatesDir, "templates directory for tmuxinator")
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ You could customize the flags
 - `--ssh_key` ssh_key file to be uploaded, defaults to `$HOME/.ssh/id_rsa.pub`
 - `--dbfile` file to store the instances and search, defaults to `$HOME/hosts.db`
 - `--projects` list of project-ids to search for while login, or to refresh
+- `--host_mapping` prints results of `search` command in the format of `/etc/hosts` file
 
 
 ```
@@ -103,7 +104,6 @@ enable syncronized panes, so most cases require you to run command on all machin
 ### TODO:
 * customize which `cmd` to run once ssh to all instances
 * customize login via external ip / internal ip via flags (currently only internal ip is supported)
-* output machine ip mapping so can be added to `/etc/hosts`, or add to file
 * Infer id from ssh key
 * revoking ssh key for user from machine
 * ssh customize project to use via flag


### PR DESCRIPTION
Add `host_mapping` option to format the results of search command in the format of `/etc/hosts` file

Also, changed the default search command output from `logger.Infof` to `fmt.Printf`